### PR TITLE
Adding SkipFirstFilter

### DIFF
--- a/src/Filter/SkipFirstFilter.php
+++ b/src/Filter/SkipFirstFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of plumphp/plum.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plum\Plum\Filter;
+
+use LogicException;
+
+/**
+ * SkipFirstFilter
+ *
+ * @package   Plum\Plum\Filter
+ * @author    Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @copyright 2015 Florian Eckerstorfer
+ */
+class SkipFirstFilter implements FilterInterface
+{
+    /** @var int */
+    private $counter;
+
+    public function __construct($counter)
+    {
+        if (!is_int($counter)) {
+            throw new LogicException('SkipFirstFilter expects an integer as first argument');
+        }
+
+        $this->counter = $counter;
+    }
+
+    /**
+     * @param mixed $item
+     *
+     * @return bool
+     */
+    public function filter($item)
+    {
+        if ($this->counter > 0) {
+            $this->counter--;
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Filter/SkipFirstFilterTest.php
+++ b/tests/Filter/SkipFirstFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of plumphp/plum.
+ *
+ * (c) Florian Eckerstorfer <florian@eckerstorfer.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plum\Plum\Filter;
+
+/**
+ * SkipFirstFilterTest
+ *
+ * @package   Plum\Plum\Filter
+ * @author    Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @copyright 2015 Florian Eckerstorfer
+ *
+ * @group unit
+ */
+class SkipFirstFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @covers Plum\Plum\Filter\SkipFirstFilter::__construct()
+     * @covers Plum\Plum\Filter\SkipFirstFilter::filter()
+     */
+    public function filterShouldSkipNoneWithCounter0()
+    {
+        $filter = new SkipFirstFilter(0);
+
+        $this->assertTrue($filter->filter('foobar'));
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Filter\SkipFirstFilter::__construct()
+     * @covers Plum\Plum\Filter\SkipFirstFilter::filter()
+     */
+    public function filterShouldSkipOneWithCounter1()
+    {
+        $filter = new SkipFirstFilter(1);
+
+        $this->assertFalse($filter->filter('foo'));
+        $this->assertTrue($filter->filter('bar'));
+    }
+
+    /**
+     * @test
+     * @expectedException \LogicException
+     * @covers Plum\Plum\Filter\SkipFirstFilter::__construct()
+     * @covers Plum\Plum\Filter\SkipFirstFilter::filter()
+     */
+    public function filterThrowExceptionIfConstructedWrong()
+    {
+        new SkipFirstFilter('wrong');
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/plumphp/plum-csv/issues/4, I added a `SkipFirstFilter` which takes the number of items to skip as constructor argument and then skips those items.
