### PR TITLE
Refactor adding pipeline elements

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -105,13 +105,13 @@ Value Converters
 ----------------
 
 Often you don't want to convert the whole item, but only a single field and Plum therefore supports value converters.
-Plum uses Vale to retrieve a field from an arbitrary array or object, apply a converter and stores the converted
-value back into its original position.
+Plum uses [Vale](https://github.com/cocur/vale) to retrieve a field from an arbitrary array or object, apply a converter
+and stores the converted value back into its original position.
 
 ```php
 $writer = new ArrayWriter();
 $workflow = new Workflow();
-$workflow->addValueConverter(['foo', 'bar', 'qoo', 'qoz'], new CallbackConverter(function ($v) { return $v*2; }));
+$workflow->addValueConverter(new CallbackConverter(function ($v) { return $v*2; }), ['foo', 'bar', 'qoo', 'qoz']);
 $workflow->addWriter($writer);
 $workflow->process(new ArrayReader([['foo' => ['bar' => ['qoo' => ['qoz' => 21]]]]]));
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -153,8 +153,8 @@ Value Filters
 -------------
 
 Sometimes you want to filter items on a single value in the item and Plum therefore supports value filters. Value
-filters use Vale to retrieve a value from an arbitrary array or object.
+filters use [Vale](https://github.com/cocur/vale) to retrieve a value from an arbitrary array or object.
 
 ```php
-$workflow->addValueFilter(['foo, 'bar', 'qoo'], $filter);
+$workflow->addValueFilter($filter, ['foo, 'bar', 'qoo']);
 ```

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -15,26 +15,81 @@ $workflow->process($reader);
 Table of Contents
 -----------------
 
+- [Adding Converters, Filters, and Writers](#adding-converters-filters-and-writers)
 - [Conditional Converters](#conditional-converters)
 - [Pipeline Order](#pipeline-order)
 - [Result](#result)
 - [Concatenating Workflows](#concatenating-workflows)
 
 
+Adding Converters, Filters, and Writers
+-------------------------------------
+
+The `add*()` methods offer two ways of adding converters, filters, and writers to the workflow. Either you pass the
+object as its first argument or you provide an array with options.
+
+### Converters
+
+```php
+$workflow->addConverter($converter);
+$workflow->addConverter(['converter' => $converter]);
+```
+
+### Value Converters
+
+```php
+$workflow->addValueConverter($converter, ['key']);
+$workflow->addValueConverter(['converter' => $converter, 'field' => ['key']]);
+```
+
+### Filters
+
+```php
+$workflow->addFilter($filter);
+$workflow->addFilter(['filter' => $filter]);
+```
+
+### Value Filters
+
+```php
+$workflow->addValueFilter($filter, ['key']);
+$workflow->addValueFilter(['filter' => $filter, 'field' => ['key']]);
+```
+
+### Writers
+
+```php
+$workflow->addWriter($writer);
+$workflow->addWriter(['writer' => $writer]);
+```
+
+
 Conditional Converters
 ----------------------
 
-The `addConverter()` method accepts an optional second parameter of type `Plum\Plum\Filter\FilterInterface`. If a
+The `addConverter()` method accepts an filter, that is, an instance `Plum\Plum\Filter\FilterInterface`. You need
+to call `addConverter()` with an array as its element. If a
 filter is provided the converter is only applied to an item if the filter returns `true` for the given item. Otherwise
 the original item is returned by the converter.
 
 ```php
 $converter = new CallbackConverter(function ($item) { return strtoupper($item); });
 $filter    = new CallbackFilter(function ($item) { return preg_match('/foo/', $item); });
-$workflow->addConverter($converter, $filter);
+$workflow->addConverter(['converter' => $converter, 'filter' => $filter]);
 
 // "foobar" -> "FOOBAR"
 // "bazbar" -> "bazbar"
+```
+
+Conditional converters also work for value converters:
+
+```php
+$converter = new CallbackConverter(function ($item) { return strtoupper($item); });
+$filter    = new CallbackFilter(function ($item) { return preg_match('/foo/', $item); });
+$workflow->addValueConverter(['converter' => $converter, 'filter' => $filter], ['k']);
+
+// ["k" => "foobar"] -> ["k" => "FOOBAR"]
+// ["k" => "bazbar"] -> ["k" => "bazbar"]
 ```
 
 
@@ -42,16 +97,16 @@ Pipeline Order
 --------------
 
 The pipeline is processed strictly in the order the filters, converters and writers are added to the workflow. You
-can pass the position of an pipeline element as the last parameter to the corresponding `add*()` method. There are
+can pass the position of an pipeline element in the array to the corresponding `add*()` method. There are
 two possible values:
 
 - `Workflow::PREPEND`
 - `Workflow::APPEND`
 
 ```php
-$workflow->addFilter($filter, Workflow::PREPEND);
-$workflow->addConverter($converter, null, Workflow::PREPEND);
-$workflow->addWriter($converter, null, Workflow::APPEND);
+$workflow->addFilter(['filter' => $filter, 'position' => Workflow::PREPEND]);
+$workflow->addConverter(['converter' => $converter, 'position' => Workflow::PREPEND]);
+$workflow->addWriter(['converter' => $converter, 'position' => Workflow::APPEND]);
 ```
 
 

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -57,13 +57,16 @@ class Workflow
     }
 
     /**
-     * @param <string,PipelineInterface> $element
-     * @param int                        $position
+     * Inserts an element into the pipeline at the given position.
+     *
+     * @param array $element
      *
      * @return Workflow
      */
-    protected function add($element, $position = self::APPEND)
+    protected function insertElement($element)
     {
+        $position = isset($element['position']) ? $element['position'] : self::APPEND;
+
         if ($position === self::PREPEND) {
             array_unshift($this->pipeline, $element);
         } else {
@@ -82,10 +85,12 @@ class Workflow
     public function addFilter(FilterInterface $filter, $position = self::APPEND)
     {
         $element = [
-            'type'   => self::PIPELINE_TYPE_FILTER,
-            'filter' => $filter
+            'type'     => self::PIPELINE_TYPE_FILTER,
+            'filter'   => $filter,
+            'position' => $position
         ];
-        return $this->add($element, $position);
+
+        return $this->insertElement($element);
     }
 
     /**
@@ -106,11 +111,13 @@ class Workflow
     public function addValueFilter($field, FilterInterface $filter, $position = self::APPEND)
     {
         $element = [
-            'type'   => self::PIPELINE_TYPE_VALUE_FILTER,
-            'filter' => $filter,
-            'field'  => $field
+            'type'     => self::PIPELINE_TYPE_VALUE_FILTER,
+            'filter'   => $filter,
+            'field'    => $field,
+            'position' => $position
         ];
-        return $this->add($element, $position);
+
+        return $this->insertElement($element);
     }
 
     /**
@@ -136,10 +143,11 @@ class Workflow
         $element = [
             'type'      => self::PIPELINE_TYPE_CONVERTER,
             'converter' => $converter,
-            'filter'    => $filter
+            'filter'    => $filter,
+            'position'  => $position
         ];
 
-        return $this->add($element, $position);
+        return $this->insertElement($element);
     }
 
     /**
@@ -168,10 +176,11 @@ class Workflow
             'type'      => self::PIPELINE_TYPE_VALUE_CONVERTER,
             'converter' => $converter,
             'filter'    => $filter,
-            'field'     => $field
+            'field'     => $field,
+            'position'  => $position
         ];
 
-        return $this->add($element, $position);
+        return $this->insertElement($element);
     }
 
     /**
@@ -192,11 +201,12 @@ class Workflow
     public function addWriter(WriterInterface $writer, FilterInterface $filter = null, $position = self::APPEND)
     {
         $element = [
-            'type'   => self::PIPELINE_TYPE_WRITER,
-            'writer' => $writer,
-            'filter' => $filter
+            'type'     => self::PIPELINE_TYPE_WRITER,
+            'writer'   => $writer,
+            'filter'   => $filter,
+            'position' => $position
         ];
-        return $this->add($element, $position);
+        return $this->insertElement($element);
     }
 
     /**

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -12,6 +12,7 @@
 namespace Plum\Plum;
 
 use Cocur\Vale\Vale;
+use InvalidArgumentException;
 use Plum\Plum\Converter\ConverterInterface;
 use Plum\Plum\Filter\FilterInterface;
 use Plum\Plum\Reader\ReaderInterface;
@@ -77,18 +78,24 @@ class Workflow
     }
 
     /**
-     * @param FilterInterface $filter
-     * @param int             $position
+     * @param array|FilterInterface $element
      *
      * @return Workflow
+     *
+     * @throws InvalidArgumentException
      */
-    public function addFilter(FilterInterface $filter, $position = self::APPEND)
+    public function addFilter($element)
     {
-        $element = [
+        if (is_object($element) && $element instanceof FilterInterface) {
+            $element = ['filter' => $element];
+        } else if (!is_array($element) || !isset($element['filter'])) {
+            throw new InvalidArgumentException('Workflow::addFilter() must be called with either an instance of "Plum\Plum\Filter\FilterInterface" or an array that contains "filter".');
+        }
+
+        $element = array_merge([
             'type'     => self::PIPELINE_TYPE_FILTER,
-            'filter'   => $filter,
-            'position' => $position
-        ];
+            'position' => self::APPEND
+        ], $element);
 
         return $this->insertElement($element);
     }
@@ -102,20 +109,26 @@ class Workflow
     }
 
     /**
-     * @param string|array    $field
-     * @param FilterInterface $filter
-     * @param int             $position
+     * @param array|FilterInterface $element
+     * @param string|null           $field
      *
      * @return Workflow
+     *
+     * @throws InvalidArgumentException
      */
-    public function addValueFilter($field, FilterInterface $filter, $position = self::APPEND)
+    public function addValueFilter($element, $field = null)
     {
-        $element = [
+        if (is_object($element) && $element instanceof FilterInterface && $field) {
+            $element = ['filter' => $element, 'field' => $field];
+        } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['filter'])
+            || !isset($element['field'])) {
+            throw new InvalidArgumentException('Workflow::addValueFilter() must be called with either an instance of "Plum\Plum\Filter\FilterInterface" and a field name or with an array that contains "filter" and "field".');
+        }
+
+        $element = array_merge([
             'type'     => self::PIPELINE_TYPE_VALUE_FILTER,
-            'filter'   => $filter,
-            'field'    => $field,
-            'position' => $position
-        ];
+            'position' => self::APPEND
+        ], $element);
 
         return $this->insertElement($element);
     }
@@ -129,23 +142,25 @@ class Workflow
     }
 
     /**
-     * @param ConverterInterface   $converter
-     * @param FilterInterface|null $filter
-     * @param int                  $position
+     * @param array|ConverterInterface $element
      *
      * @return Workflow $this
+     *
+     * @throws InvalidArgumentException
      */
-    public function addConverter(
-        ConverterInterface $converter,
-        FilterInterface $filter = null,
-        $position = self::APPEND
-    ) {
-        $element = [
+    public function addConverter($element)
+    {
+        if (is_object($element) && $element instanceof ConverterInterface) {
+            $element = ['converter' => $element];
+        } else if (!is_array($element) || !isset($element['converter'])) {
+            throw new InvalidArgumentException('Workflow::addConverter() must be called with either an instance of "Plum\Plum\Converter\ConverterInterface" or with an array that contains "converter".');
+        }
+
+        $element = array_merge([
             'type'      => self::PIPELINE_TYPE_CONVERTER,
-            'converter' => $converter,
-            'filter'    => $filter,
-            'position'  => $position
-        ];
+            'filter'    => null,
+            'position'  => self::APPEND
+        ], $element);
 
         return $this->insertElement($element);
     }
@@ -159,26 +174,27 @@ class Workflow
     }
 
     /**
-     * @param string|array       $field
-     * @param ConverterInterface $converter
-     * @param FilterInterface    $filter
-     * @param int                $position
+     * @param array|ConverterInterface $element
+     * @param string|null              $field
      *
      * @return Workflow
+     *
+     * @throws InvalidArgumentException
      */
-    public function addValueConverter(
-        $field,
-        ConverterInterface $converter,
-        FilterInterface $filter = null,
-        $position = self::APPEND
-    ) {
-        $element = [
-            'type'      => self::PIPELINE_TYPE_VALUE_CONVERTER,
-            'converter' => $converter,
-            'filter'    => $filter,
-            'field'     => $field,
-            'position'  => $position
-        ];
+    public function addValueConverter($element, $field = null)
+    {
+        if (is_object($element) && $element instanceof ConverterInterface && $field) {
+            $element = ['converter' => $element, 'field' => $field];
+        } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['converter'])
+            || !isset($element['field'])) {
+            throw new InvalidArgumentException('Workflow::addValueConverter() must be called with either an instance of "Plum\Plum\Converter\ConverterInterface" and a field name or with an array that contains "converter" and "field".');
+        }
+
+        $element = array_merge([
+            'type'     => self::PIPELINE_TYPE_VALUE_CONVERTER,
+            'filter'   => null,
+            'position' => self::APPEND
+        ], $element);
 
         return $this->insertElement($element);
     }
@@ -192,20 +208,26 @@ class Workflow
     }
 
     /**
-     * @param WriterInterface      $writer
-     * @param FilterInterface|null $filter
-     * @param int                  $position
+     * @param array|WriterInterface $element
      *
      * @return Workflow
+     *
+     * @throws InvalidArgumentException
      */
-    public function addWriter(WriterInterface $writer, FilterInterface $filter = null, $position = self::APPEND)
+    public function addWriter($element)
     {
-        $element = [
+        if (is_object($element) && $element instanceof WriterInterface) {
+            $element = ['writer' => $element];
+        } else if (!is_array($element) || !isset($element['writer'])) {
+            throw new InvalidArgumentException('Workflow::addWriter() must be called with either an instance of "Plum\Plum\Writer\WriterInterface" or with an array that contains "writer".');
+        }
+
+        $element = array_merge([
             'type'     => self::PIPELINE_TYPE_WRITER,
-            'writer'   => $writer,
-            'filter'   => $filter,
-            'position' => $position
-        ];
+            'filter'   => null,
+            'position' => self::APPEND
+        ], $element);
+
         return $this->insertElement($element);
     }
 

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -88,7 +88,8 @@ class Workflow
     {
         if (is_object($element) && $element instanceof FilterInterface) {
             $element = ['filter' => $element];
-        } else if (!is_array($element) || !isset($element['filter'])) {
+        } else if (!is_array($element) || !isset($element['filter'])
+                || !$element['filter'] instanceof FilterInterface) {
             throw new InvalidArgumentException('Workflow::addFilter() must be called with either an instance of "Plum\Plum\Filter\FilterInterface" or an array that contains "filter".');
         }
 
@@ -121,7 +122,7 @@ class Workflow
         if (is_object($element) && $element instanceof FilterInterface && $field) {
             $element = ['filter' => $element, 'field' => $field];
         } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['filter'])
-            || !isset($element['field'])) {
+                || !isset($element['field']) || !$element['filter'] instanceof FilterInterface) {
             throw new InvalidArgumentException('Workflow::addValueFilter() must be called with either an instance of "Plum\Plum\Filter\FilterInterface" and a field name or with an array that contains "filter" and "field".');
         }
 
@@ -152,7 +153,8 @@ class Workflow
     {
         if (is_object($element) && $element instanceof ConverterInterface) {
             $element = ['converter' => $element];
-        } else if (!is_array($element) || !isset($element['converter'])) {
+        } else if (!is_array($element) || !isset($element['converter'])
+                || !$element['converter'] instanceof ConverterInterface) {
             throw new InvalidArgumentException('Workflow::addConverter() must be called with either an instance of "Plum\Plum\Converter\ConverterInterface" or with an array that contains "converter".');
         }
 
@@ -186,7 +188,7 @@ class Workflow
         if (is_object($element) && $element instanceof ConverterInterface && $field) {
             $element = ['converter' => $element, 'field' => $field];
         } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['converter'])
-            || !isset($element['field'])) {
+            || !isset($element['field']) || !$element['converter'] instanceof ConverterInterface) {
             throw new InvalidArgumentException('Workflow::addValueConverter() must be called with either an instance of "Plum\Plum\Converter\ConverterInterface" and a field name or with an array that contains "converter" and "field".');
         }
 
@@ -218,7 +220,8 @@ class Workflow
     {
         if (is_object($element) && $element instanceof WriterInterface) {
             $element = ['writer' => $element];
-        } else if (!is_array($element) || !isset($element['writer'])) {
+        } else if (!is_array($element) || !isset($element['writer'])
+                || !$element['writer'] instanceof WriterInterface) {
             throw new InvalidArgumentException('Workflow::addWriter() must be called with either an instance of "Plum\Plum\Writer\WriterInterface" or with an array that contains "writer".');
         }
 

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -73,7 +73,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $this->workflow->addFilter($filter);
 
-        $this->assertContains($filter, $this->workflow->getFilters());
+        $this->assertSame($filter, $this->workflow->getFilters()[0]['filter']);
     }
 
     /**
@@ -89,8 +89,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->workflow->addFilter($filter1);
         $this->workflow->addFilter($filter2, Workflow::PREPEND);
 
-        $this->assertSame($filter2, $this->workflow->getFilters()[0]);
-        $this->assertSame($filter1, $this->workflow->getFilters()[1]);
+        $this->assertSame($filter2, $this->workflow->getFilters()[0]['filter']);
+        $this->assertSame($filter1, $this->workflow->getFilters()[1]['filter']);
     }
 
     /**
@@ -104,7 +104,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $this->workflow->addValueFilter(['foo'], $filter);
 
-        $this->assertContains($filter, $this->workflow->getValueFilters());
+        $this->assertSame($filter, $this->workflow->getValueFilters()[0]['filter']);
     }
 
     /**
@@ -120,8 +120,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->workflow->addValueFilter(['foo'], $filter1);
         $this->workflow->addValueFilter(['foo'], $filter2, Workflow::PREPEND);
 
-        $this->assertSame($filter2, $this->workflow->getValueFilters()[0]);
-        $this->assertSame($filter1, $this->workflow->getValueFilters()[1]);
+        $this->assertSame($filter2, $this->workflow->getValueFilters()[0]['filter']);
+        $this->assertSame($filter1, $this->workflow->getValueFilters()[1]['filter']);
     }
 
     /**
@@ -135,7 +135,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $converter = $this->getMockConverter();
         $this->workflow->addConverter($converter);
 
-        $this->assertContains($converter, $this->workflow->getConverters());
+        $this->assertSame($converter, $this->workflow->getConverters()[0]['converter']);
     }
 
     /**
@@ -151,8 +151,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->workflow->addConverter($converter1);
         $this->workflow->addConverter($converter2, null, Workflow::PREPEND);
 
-        $this->assertSame($converter2, $this->workflow->getConverters()[0]);
-        $this->assertSame($converter1, $this->workflow->getConverters()[1]);
+        $this->assertSame($converter2, $this->workflow->getConverters()[0]['converter']);
+        $this->assertSame($converter1, $this->workflow->getConverters()[1]['converter']);
     }
 
     /**
@@ -166,7 +166,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $converter = $this->getMockConverter();
         $this->workflow->addValueConverter(['foo'], $converter);
 
-        $this->assertContains($converter, $this->workflow->getValueConverters());
+        $this->assertSame($converter, $this->workflow->getValueConverters()[0]['converter']);
     }
 
     /**
@@ -182,8 +182,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->workflow->addValueConverter(['foo'], $converter1);
         $this->workflow->addValueConverter(['foo'], $converter2, null, Workflow::PREPEND);
 
-        $this->assertSame($converter2, $this->workflow->getValueConverters()[0]);
-        $this->assertSame($converter1, $this->workflow->getValueConverters()[1]);
+        $this->assertSame($converter2, $this->workflow->getValueConverters()[0]['converter']);
+        $this->assertSame($converter1, $this->workflow->getValueConverters()[1]['converter']);
     }
 
     /**
@@ -197,7 +197,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $writer = $this->getMockWriter();
         $this->workflow->addWriter($writer);
 
-        $this->assertContains($writer, $this->workflow->getWriters());
+        $this->assertSame($writer, $this->workflow->getWriters()[0]['writer']);
     }
 
     /**
@@ -213,8 +213,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->workflow->addWriter($writer1);
         $this->workflow->addWriter($writer2, null, Workflow::PREPEND);
 
-        $this->assertSame($writer2, $this->workflow->getWriters()[0]);
-        $this->assertSame($writer1, $this->workflow->getWriters()[1]);
+        $this->assertSame($writer2, $this->workflow->getWriters()[0]['writer']);
+        $this->assertSame($writer1, $this->workflow->getWriters()[1]['writer']);
     }
 
     /**

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -68,10 +68,24 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      * @covers Plum\Plum\Workflow::addFilter()
      * @covers Plum\Plum\Workflow::getFilters()
      */
-    public function addFilterShouldAddFilterToWorkflow()
+    public function addFilterWithFilterInstanceShouldAddFilterToWorkflow()
     {
         $filter = $this->getMockFilter();
         $this->workflow->addFilter($filter);
+
+        $this->assertSame($filter, $this->workflow->getFilters()[0]['filter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::insertElement()
+     * @covers Plum\Plum\Workflow::addFilter()
+     * @covers Plum\Plum\Workflow::getFilters()
+     */
+    public function addFilterWithArrayShouldAddFilterToWorkflow()
+    {
+        $filter = $this->getMockFilter();
+        $this->workflow->addFilter(['filter' => $filter]);
 
         $this->assertSame($filter, $this->workflow->getFilters()[0]['filter']);
     }
@@ -87,7 +101,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter1 = $this->getMockFilter();
         $filter2 = $this->getMockFilter();
         $this->workflow->addFilter($filter1);
-        $this->workflow->addFilter($filter2, Workflow::PREPEND);
+        $this->workflow->addFilter(['filter' => $filter2, 'position' => Workflow::PREPEND]);
 
         $this->assertSame($filter2, $this->workflow->getFilters()[0]['filter']);
         $this->assertSame($filter1, $this->workflow->getFilters()[1]['filter']);
@@ -99,10 +113,24 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      * @covers Plum\Plum\Workflow::addValueFilter()
      * @covers Plum\Plum\Workflow::getValueFilters()
      */
-    public function addValueFilterShouldAddValueFilterToWorkflow()
+    public function addValueFilterWithFilterInstanceShouldAddValueFilterToWorkflow()
     {
         $filter = $this->getMockFilter();
-        $this->workflow->addValueFilter(['foo'], $filter);
+        $this->workflow->addValueFilter($filter, ['foo']);
+
+        $this->assertSame($filter, $this->workflow->getValueFilters()[0]['filter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::insertElement()
+     * @covers Plum\Plum\Workflow::addValueFilter()
+     * @covers Plum\Plum\Workflow::getValueFilters()
+     */
+    public function addValueFilterWithArrayShouldAddValueFilterToWorkflow()
+    {
+        $filter = $this->getMockFilter();
+        $this->workflow->addValueFilter(['filter' => $filter, 'field' => ['foo']]);
 
         $this->assertSame($filter, $this->workflow->getValueFilters()[0]['filter']);
     }
@@ -117,8 +145,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
     {
         $filter1 = $this->getMockFilter();
         $filter2 = $this->getMockFilter();
-        $this->workflow->addValueFilter(['foo'], $filter1);
-        $this->workflow->addValueFilter(['foo'], $filter2, Workflow::PREPEND);
+        $this->workflow->addValueFilter($filter1, ['foo']);
+        $this->workflow->addValueFilter(['field' => ['foo'], 'filter' => $filter2, 'position' => Workflow::PREPEND]);
 
         $this->assertSame($filter2, $this->workflow->getValueFilters()[0]['filter']);
         $this->assertSame($filter1, $this->workflow->getValueFilters()[1]['filter']);
@@ -130,10 +158,24 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      * @covers Plum\Plum\Workflow::addConverter()
      * @covers Plum\Plum\Workflow::getConverters()
      */
-    public function addConverterShouldAddConverterToWorkflow()
+    public function addConverterWithConverterInstanceShouldAddConverterToWorkflow()
     {
         $converter = $this->getMockConverter();
         $this->workflow->addConverter($converter);
+
+        $this->assertSame($converter, $this->workflow->getConverters()[0]['converter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::insertElement()
+     * @covers Plum\Plum\Workflow::addConverter()
+     * @covers Plum\Plum\Workflow::getConverters()
+     */
+    public function addConverterWithArrayShouldAddConverterToWorkflow()
+    {
+        $converter = $this->getMockConverter();
+        $this->workflow->addConverter(['converter' => $converter]);
 
         $this->assertSame($converter, $this->workflow->getConverters()[0]['converter']);
     }
@@ -149,7 +191,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $converter1 = $this->getMockConverter();
         $converter2 = $this->getMockConverter();
         $this->workflow->addConverter($converter1);
-        $this->workflow->addConverter($converter2, null, Workflow::PREPEND);
+        $this->workflow->addConverter(['converter' => $converter2, 'position' => Workflow::PREPEND]);
 
         $this->assertSame($converter2, $this->workflow->getConverters()[0]['converter']);
         $this->assertSame($converter1, $this->workflow->getConverters()[1]['converter']);
@@ -161,10 +203,24 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      * @covers Plum\Plum\Workflow::addValueConverter()
      * @covers Plum\Plum\Workflow::getValueConverters()
      */
-    public function addValueConverterShouldAddValueConverterToWorkflow()
+    public function addValueConverterWithConverterInstanceShouldAddValueConverterToWorkflow()
     {
         $converter = $this->getMockConverter();
-        $this->workflow->addValueConverter(['foo'], $converter);
+        $this->workflow->addValueConverter($converter, ['foo']);
+
+        $this->assertSame($converter, $this->workflow->getValueConverters()[0]['converter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::insertElement()
+     * @covers Plum\Plum\Workflow::addValueConverter()
+     * @covers Plum\Plum\Workflow::getValueConverters()
+     */
+    public function addValueConverterWithArrayShouldAddValueConverterToWorkflow()
+    {
+        $converter = $this->getMockConverter();
+        $this->workflow->addValueConverter(['converter' => $converter, 'field' => ['foo']]);
 
         $this->assertSame($converter, $this->workflow->getValueConverters()[0]['converter']);
     }
@@ -179,8 +235,12 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
     {
         $converter1 = $this->getMockConverter();
         $converter2 = $this->getMockConverter();
-        $this->workflow->addValueConverter(['foo'], $converter1);
-        $this->workflow->addValueConverter(['foo'], $converter2, null, Workflow::PREPEND);
+        $this->workflow->addValueConverter($converter1, ['foo']);
+        $this->workflow->addValueConverter([
+            'field'     => ['foo'],
+            'converter' => $converter2,
+            'position'  => Workflow::PREPEND
+        ]);
 
         $this->assertSame($converter2, $this->workflow->getValueConverters()[0]['converter']);
         $this->assertSame($converter1, $this->workflow->getValueConverters()[1]['converter']);
@@ -192,10 +252,24 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      * @covers Plum\Plum\Workflow::addWriter()
      * @covers Plum\Plum\Workflow::getWriters()
      */
-    public function addWriterShouldAddWriterToWorkflow()
+    public function addWriterWithWriterInstanceShouldAddWriterToWorkflow()
     {
         $writer = $this->getMockWriter();
         $this->workflow->addWriter($writer);
+
+        $this->assertSame($writer, $this->workflow->getWriters()[0]['writer']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::insertElement()
+     * @covers Plum\Plum\Workflow::addWriter()
+     * @covers Plum\Plum\Workflow::getWriters()
+     */
+    public function addWriterWithArrayShouldAddWriterToWorkflow()
+    {
+        $writer = $this->getMockWriter();
+        $this->workflow->addWriter(['writer' => $writer]);
 
         $this->assertSame($writer, $this->workflow->getWriters()[0]['writer']);
     }
@@ -211,7 +285,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $writer1 = $this->getMockWriter();
         $writer2 = $this->getMockWriter();
         $this->workflow->addWriter($writer1);
-        $this->workflow->addWriter($writer2, null, Workflow::PREPEND);
+        $this->workflow->addWriter(['writer' => $writer2, 'position' => Workflow::PREPEND]);
 
         $this->assertSame($writer2, $this->workflow->getWriters()[0]['writer']);
         $this->assertSame($writer1, $this->workflow->getWriters()[1]['writer']);
@@ -282,7 +356,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->with('foobar')->once()->andReturn(false);
-        $this->workflow->addValueFilter(['foo'], $filter);
+        $this->workflow->addValueFilter($filter, ['foo']);
 
         $result = $this->workflow->process($reader);
 
@@ -341,7 +415,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->with('foobar')->once()->andReturn(true);
 
-        $this->workflow->addConverter($converter, $filter);
+        $this->workflow->addConverter(['converter' => $converter, 'filter' => $filter]);
 
         $result = $this->workflow->process($reader);
 
@@ -372,7 +446,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->with('foobar')->once()->andReturn(false);
 
-        $this->workflow->addConverter($converter, $filter);
+        $this->workflow->addConverter(['converter' => $converter, 'filter' => $filter]);
 
         $result = $this->workflow->process($reader);
 
@@ -399,7 +473,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $converter = $this->getMockConverter();
         $converter->shouldReceive('convert')->with('foobar')->once()->andReturn('FOOBAR');
-        $this->workflow->addValueConverter(['foo'], $converter);
+        $this->workflow->addValueConverter($converter, ['foo']);
 
         $writer = $this->getMockWriter();
         $writer->shouldReceive('prepare');
@@ -436,7 +510,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->with('foobar')->once()->andReturn(true);
 
-        $this->workflow->addValueConverter(['foo'], $converter, $filter);
+        $this->workflow->addValueConverter(['field' => ['foo'], 'converter' => $converter, 'filter' => $filter]);
 
         $writer = $this->getMockWriter();
         $writer->shouldReceive('prepare');
@@ -473,7 +547,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->with('foobar')->once()->andReturn(false);
 
-        $this->workflow->addValueConverter(['foo'], $converter, $filter);
+        $this->workflow->addValueConverter(['field' => ['foo'], 'converter' => $converter, 'filter' => $filter]);
 
         $result = $this->workflow->process($reader);
 
@@ -541,7 +615,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->once()->andReturn(true);
 
-        $this->workflow->addWriter($writer, $filter);
+        $this->workflow->addWriter(['writer' => $writer, 'filter' => $filter]);
 
         $result = $this->workflow->process($reader);
 
@@ -578,7 +652,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $filter = $this->getMockFilter();
         $filter->shouldReceive('filter')->once()->andReturn(false);
 
-        $this->workflow->addWriter($writer, $filter);
+        $this->workflow->addWriter(['writer' => $writer, 'filter' => $filter]);
 
         $result = $this->workflow->process($reader);
 

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -64,7 +64,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addFilter()
      * @covers Plum\Plum\Workflow::getFilters()
      */
@@ -78,7 +78,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addFilter()
      * @covers Plum\Plum\Workflow::getFilters()
      */
@@ -95,7 +95,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addValueFilter()
      * @covers Plum\Plum\Workflow::getValueFilters()
      */
@@ -109,7 +109,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addValueFilter()
      * @covers Plum\Plum\Workflow::getValueFilters()
      */
@@ -126,7 +126,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addConverter()
      * @covers Plum\Plum\Workflow::getConverters()
      */
@@ -140,7 +140,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addConverter()
      * @covers Plum\Plum\Workflow::getConverters()
      */
@@ -157,7 +157,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addValueConverter()
      * @covers Plum\Plum\Workflow::getValueConverters()
      */
@@ -171,7 +171,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addValueConverter()
      * @covers Plum\Plum\Workflow::getValueConverters()
      */
@@ -188,7 +188,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addWriter()
      * @covers Plum\Plum\Workflow::getWriters()
      */
@@ -202,7 +202,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @covers Plum\Plum\Workflow::add()
+     * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addWriter()
      * @covers Plum\Plum\Workflow::getWriters()
      */

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -109,6 +109,36 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers            Plum\Plum\Workflow::addFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addFilterThrowsExceptionIfElementIsNotAFilterAndNotAnArray()
+    {
+        $this->workflow->addFilter('invalid');
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addFilterThrowsExceptionIfArrayDoesNotContainFilter()
+    {
+        $this->workflow->addFilter([]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addFilterThrowsExceptionIfFilterInArrayIsNotFilter()
+    {
+        $this->workflow->addFilter(['filter' => 'invalid']);
+    }
+
+    /**
+     * @test
      * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addValueFilter()
      * @covers Plum\Plum\Workflow::getValueFilters()
@@ -154,6 +184,56 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers            Plum\Plum\Workflow::addValueFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueFilterThrowsExceptionIfElementIsNotAnArrayAndNotAFilter()
+    {
+        $this->workflow->addValueFilter('invalid', ['foo']);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueFilterThrowsExceptionIfFieldIsMissing()
+    {
+        $this->workflow->addValueFilter($this->getMockFilter(), null);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueFilterThrowsExceptionIfFieldIsMissingInArray()
+    {
+        $this->workflow->addValueFilter(['filter' => $this->getMockFilter()]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueFilterThrowsExceptionIfFilterIsMissingInArray()
+    {
+        $this->workflow->addValueFilter(['field' => ['foo']]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueFilter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueFilterThrowsExceptionIfFilterInArrayIsNotFilter()
+    {
+        $this->workflow->addValueFilter(['field' => ['foo'], 'filter' => 'invalid']);
+    }
+
+    /**
+     * @test
      * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addConverter()
      * @covers Plum\Plum\Workflow::getConverters()
@@ -195,6 +275,36 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($converter2, $this->workflow->getConverters()[0]['converter']);
         $this->assertSame($converter1, $this->workflow->getConverters()[1]['converter']);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addConverterThrowsExceptionIfElementIsNotAConverterAndNotAnArray()
+    {
+        $this->workflow->addConverter('invalid');
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addConverterThrowsExceptionIfConverterIsMissingInArray()
+    {
+        $this->workflow->addConverter([]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addConverterThrowsExceptionIfConverterInArrayIsNotConverter()
+    {
+        $this->workflow->addConverter(['converter' => 'invalid']);
     }
 
     /**
@@ -248,6 +358,56 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers            Plum\Plum\Workflow::addValueConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueConverterThrowsExceptionIfElementIsNotAnArrayAndNotAConverter()
+    {
+        $this->workflow->addValueConverter('invalid', ['foo']);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueConverterThrowsExceptionIfFieldIsMissing()
+    {
+        $this->workflow->addValueConverter($this->getMockConverter(), null);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueConverterThrowsExceptionIfFieldIsMissingInArray()
+    {
+        $this->workflow->addValueConverter(['converter' => $this->getMockConverter()]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueConverterThrowsExceptionIfConverterIsMissingInArray()
+    {
+        $this->workflow->addValueConverter(['field' => ['foo']]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addValueConverter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addValueConverterThrowsExceptionIfConverterIsInArrayIsNotConverter()
+    {
+        $this->workflow->addValueConverter(['field' => ['foo'], 'converter' => 'invalid']);
+    }
+
+    /**
+     * @test
      * @covers Plum\Plum\Workflow::insertElement()
      * @covers Plum\Plum\Workflow::addWriter()
      * @covers Plum\Plum\Workflow::getWriters()
@@ -289,6 +449,36 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($writer2, $this->workflow->getWriters()[0]['writer']);
         $this->assertSame($writer1, $this->workflow->getWriters()[1]['writer']);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addWriter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addWriterThrowsExceptionIfElementIsNotAnArrayAndNotAWriter()
+    {
+        $this->workflow->addWriter('invalid');
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addWriter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addWriterThrowsExceptionIfWriterIsMissingInArray()
+    {
+        $this->workflow->addWriter([]);
+    }
+
+    /**
+     * @test
+     * @covers            Plum\Plum\Workflow::addWriter()
+     * @expectedException \InvalidArgumentException
+     */
+    public function addWriterThrowsExceptionIfWriterInArrayIsNotWriter()
+    {
+        $this->workflow->addWriter(['writer' => 'invalid']);
     }
 
     /**


### PR DESCRIPTION
This PR refactors the way how pipeline elements can be added to the workflow. The documentation has already been updated, but in short instead of requiring multiple arguments the options are now passed as an array. The first element can be either an array or a pipeline element (if no options are required).

Adding a converter would look like this:

``` php
$workflow->addConverter($converter);
$workflow->addConverter(['converter' => $converter, 'position' => ..., 'filter' => ....]);
```
