### PR TITLE
Allow callbacks as converters and filters

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -18,6 +18,7 @@ Table of Contents
 - [Adding Converters, Filters, and Writers](#adding-converters-filters-and-writers)
 - [Conditional Converters](#conditional-converters)
 - [Pipeline Order](#pipeline-order)
+- [Callback Converters, and Filters](#callback-converters-and-filter)
 - [Result](#result)
 - [Concatenating Workflows](#concatenating-workflows)
 
@@ -107,6 +108,31 @@ two possible values:
 $workflow->addFilter(['filter' => $filter, 'position' => Workflow::PREPEND]);
 $workflow->addConverter(['converter' => $converter, 'position' => Workflow::PREPEND]);
 $workflow->addWriter(['converter' => $converter, 'position' => Workflow::APPEND]);
+```
+
+
+Callback Converters and Filters
+--------------------------------
+
+`CallbackConverter` is a converter that executes a callback to convert an item. When adding a converter or value
+converter to a `Workflow` you can just pass the callback and the workflow will automatically create a 
+`CallbackConverter`. This works for both the direct as well as the array syntax.
+
+```php
+$workflow->addConverter(function ($item) { return strtoupper($item); });
+$workflow->addConverter(['converter' => function ($item) { return strtoupper($item); }]);
+$workflow->addValueConverter(function ($item) { return strtoupper($item); }, ['foo']);
+$workflow->addValueConverter(['converter' => function ($item) { return strtoupper($item); }, 'field' => ['foo']]);
+```
+
+`CallbackFilter` is a filter that executes a callback and filters the item based on the return value of the callback.
+Just like with converters you can just pass the callback and the workflow will create a `CallbackConverter` for you.
+
+```php
+$workflow->addFilter(function ($item) { return strtoupper($item); });
+$workflow->addFilter(['filter' => function ($item) { return strtoupper($item); }]);
+$workflow->addValueFilter(function ($item) { return strtoupper($item); }, ['foo']);
+$workflow->addValueFilter(['filter' => function ($item) { return strtoupper($item); }, 'field' => ['foo']]);
 ```
 
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -135,6 +135,8 @@ $workflow->addValueFilter(function ($item) { return strtoupper($item); }, ['foo'
 $workflow->addValueFilter(['filter' => function ($item) { return strtoupper($item); }, 'field' => ['foo']]);
 ```
 
+In addition it is also possible to use callbacks as filters in conditional converters.
+
 
 Result
 ------

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -23,6 +23,9 @@ class CallbackFilter implements FilterInterface
     /** @var callable */
     private $callback;
 
+    /**
+     * @param callable $callback
+     */
     public function __construct($callback)
     {
         $this->callback = $callback;

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -13,7 +13,9 @@ namespace Plum\Plum;
 
 use Cocur\Vale\Vale;
 use InvalidArgumentException;
+use Plum\Plum\Converter\CallbackConverter;
 use Plum\Plum\Converter\ConverterInterface;
+use Plum\Plum\Filter\CallbackFilter;
 use Plum\Plum\Filter\FilterInterface;
 use Plum\Plum\Reader\ReaderInterface;
 use Plum\Plum\Writer\WriterInterface;
@@ -86,6 +88,11 @@ class Workflow
      */
     public function addFilter($element)
     {
+        if (is_callable($element)) {
+            $element = new CallbackFilter($element);
+        } else if (is_array($element) && isset($element['filter']) && is_callable($element['filter'])) {
+            $element['filter'] = new CallbackFilter($element['filter']);
+        }
         if (is_object($element) && $element instanceof FilterInterface) {
             $element = ['filter' => $element];
         } else if (!is_array($element) || !isset($element['filter'])
@@ -119,6 +126,11 @@ class Workflow
      */
     public function addValueFilter($element, $field = null)
     {
+        if (is_callable($element)) {
+            $element = new CallbackFilter($element);
+        } else if (is_array($element) && isset($element['filter']) && is_callable($element['filter'])) {
+            $element['filter'] = new CallbackFilter($element['filter']);
+        }
         if (is_object($element) && $element instanceof FilterInterface && $field) {
             $element = ['filter' => $element, 'field' => $field];
         } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['filter'])
@@ -143,7 +155,7 @@ class Workflow
     }
 
     /**
-     * @param array|ConverterInterface $element
+     * @param array|ConverterInterface|callback $element
      *
      * @return Workflow $this
      *
@@ -151,6 +163,15 @@ class Workflow
      */
     public function addConverter($element)
     {
+        if (is_callable($element)) {
+            $element = new CallbackConverter($element);
+        } else if (is_array($element) && isset($element['converter']) && is_callable($element['converter'])) {
+            $element['converter'] = new CallbackConverter($element['converter']);
+        }
+        if (is_array($element) && isset($element['filter']) && is_callable($element['filter'])) {
+            $element['filter'] = new CallbackFilter($element['filter']);
+        }
+
         if (is_object($element) && $element instanceof ConverterInterface) {
             $element = ['converter' => $element];
         } else if (!is_array($element) || !isset($element['converter'])
@@ -176,8 +197,8 @@ class Workflow
     }
 
     /**
-     * @param array|ConverterInterface $element
-     * @param string|null              $field
+     * @param array|ConverterInterface|callback $element
+     * @param string|null                       $field
      *
      * @return Workflow
      *
@@ -185,6 +206,15 @@ class Workflow
      */
     public function addValueConverter($element, $field = null)
     {
+        if (is_callable($element)) {
+            $element = new CallbackConverter($element);
+        } else if (is_array($element) && isset($element['converter']) && is_callable($element['converter'])) {
+            $element['converter'] = new CallbackConverter($element['converter']);
+        }
+        if (is_array($element) && isset($element['filter']) && is_callable($element['filter'])) {
+            $element['filter'] = new CallbackFilter($element['filter']);
+        }
+
         if (is_object($element) && $element instanceof ConverterInterface && $field) {
             $element = ['converter' => $element, 'field' => $field];
         } else if (!is_array($element) || (!is_array($element) && !$field) || !isset($element['converter'])
@@ -218,6 +248,9 @@ class Workflow
      */
     public function addWriter($element)
     {
+        if (is_array($element) && isset($element['filter']) && is_callable($element['filter'])) {
+            $element['filter'] = new CallbackFilter($element['filter']);
+        }
         if (is_object($element) && $element instanceof WriterInterface) {
             $element = ['writer' => $element];
         } else if (!is_array($element) || !isset($element['writer'])

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -109,6 +109,28 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers Plum\Plum\Workflow::addFilter()
+     */
+    public function addFilterConvertsCallbackIntoCallbackConverter()
+    {
+        $this->workflow->addFilter(function ($item) { return $item; });
+
+        $this->assertInstanceOf('Plum\Plum\Filter\FilterInterface', $this->workflow->getFilters()[0]['filter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addFilter()
+     */
+    public function addFilterConvertsCallbackInArrayIntoCallbackConverter()
+    {
+        $this->workflow->addFilter(['filter' => function ($item) { return $item; }]);
+
+        $this->assertInstanceOf('Plum\Plum\Filter\FilterInterface', $this->workflow->getFilters()[0]['filter']);
+    }
+
+    /**
+     * @test
      * @covers            Plum\Plum\Workflow::addFilter()
      * @expectedException \InvalidArgumentException
      */
@@ -180,6 +202,34 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($filter2, $this->workflow->getValueFilters()[0]['filter']);
         $this->assertSame($filter1, $this->workflow->getValueFilters()[1]['filter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addValueFilter()
+     */
+    public function addValueFilterConvertsCallbackIntoCallbackConverter()
+    {
+        $this->workflow->addValueFilter(function ($item) { return $item; }, ['foo']);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Filter\FilterInterface',
+            $this->workflow->getValueFilters()[0]['filter']
+        );
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addValueFilter()
+     */
+    public function addValueFilterConvertsCallbackInArrayIntoCallbackConverter()
+    {
+        $this->workflow->addValueFilter(['filter' => function ($item) { return $item; }, 'field' => ['foo']]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Filter\FilterInterface',
+            $this->workflow->getValueFilters()[0]['filter']
+        );
     }
 
     /**
@@ -279,6 +329,51 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers Plum\Plum\Workflow::addConverter()
+     */
+    public function addConverterConvertsCallbackIntoCallbackConverter()
+    {
+        $this->workflow->addConverter(function ($item) { return $item; });
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Converter\ConverterInterface',
+            $this->workflow->getConverters()[0]['converter']
+        );
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addConverter()
+     */
+    public function addConverterConvertsCallbackInArrayIntoCallbackConverter()
+    {
+        $this->workflow->addConverter(['converter' => function ($item) { return $item; }]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Converter\ConverterInterface',
+            $this->workflow->getConverters()[0]['converter']
+        );
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addConverter()
+     */
+    public function addConverterConvertsFilterCallbackInArrayIntoCallbackFilter()
+    {
+        $this->workflow->addConverter([
+            'converter' => $this->getMockConverter(),
+            'filter'    => function ($item) { return true; }
+        ]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Filter\FilterInterface',
+            $this->workflow->getConverters()[0]['filter']
+        );
+    }
+
+    /**
+     * @test
      * @covers            Plum\Plum\Workflow::addConverter()
      * @expectedException \InvalidArgumentException
      */
@@ -354,6 +449,52 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($converter2, $this->workflow->getValueConverters()[0]['converter']);
         $this->assertSame($converter1, $this->workflow->getValueConverters()[1]['converter']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addValueConverter()
+     */
+    public function addValueConverterAcceptsCallbackAndCreatesCallbackConverter()
+    {
+        $this->workflow->addValueConverter(function ($item) { return $item; }, ['foo']);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Converter\ConverterInterface',
+            $this->workflow->getValueConverters()[0]['converter']
+        );
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addValueConverter()
+     */
+    public function addValueConverterAcceptsCallbackInArrayAndCreatesCallbackConverter()
+    {
+        $this->workflow->addValueConverter(['converter' => function ($item) { return $item; }, 'field' => ['foo']]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Converter\ConverterInterface',
+            $this->workflow->getValueConverters()[0]['converter']
+        );
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addValueConverter()
+     */
+    public function addValueConverterAcceptsCallbackFilterInArrayAndCreatesCallbackFilter()
+    {
+        $this->workflow->addValueConverter([
+            'converter' => $this->getMockConverter(),
+            'field'     => ['foo'],
+            'filter'    => function ($item) { return true; }
+        ]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Filter\FilterInterface',
+            $this->workflow->getValueConverters()[0]['filter']
+        );
     }
 
     /**
@@ -449,6 +590,23 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($writer2, $this->workflow->getWriters()[0]['writer']);
         $this->assertSame($writer1, $this->workflow->getWriters()[1]['writer']);
+    }
+
+    /**
+     * @test
+     * @covers Plum\Plum\Workflow::addWriter()
+     */
+    public function addWriterConvertsFilterCallbackInArrayIntoCallbackFilter()
+    {
+        $this->workflow->addWriter([
+            'writer' => $this->getMockWriter(),
+            'filter' => function ($item) { return true; }
+        ]);
+
+        $this->assertInstanceOf(
+            'Plum\Plum\Filter\FilterInterface',
+            $this->workflow->getWriters()[0]['filter']
+        );
     }
 
     /**


### PR DESCRIPTION
Callback converters and filters are super convenient, but it's cumbersome to always create an instance of `CallbackConverter` or `CallbackFilter`. This PR allows passing callbacks directly to the workflow and the workflow will convert them into `CallbackConverter` and `CallbackFilter`.
