### PR TITLE
Convert only $item to null value in NullConverter

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -261,13 +261,22 @@ $converter->convert(['bar' => 'foobar'); // -> 'foobar'
 
 ### `NullConverter`
 
-`Plum\Plum\Converter\NullConverter` converts `null` values into an empty string.
+`Plum\Plum\Converter\NullConverter` converts `null` values into a null value (by default the empty string).
 
 ```php
 use Plum\Plum\Converter\NullConverter;
 
 $converter = new NullConverter();
 $converter->convert(null); // -> ""
+```
+
+You can also define which value `null` values should have assigned to.
+
+```php
+use Plum\Plum\Converter\NullConverter;
+
+$converter = new NullConverter(0);
+$converter->convert(null); // -> 0
 ```
 
 

--- a/src/Converter/NullConverter.php
+++ b/src/Converter/NullConverter.php
@@ -21,22 +21,27 @@ namespace Plum\Plum\Converter;
 class NullConverter implements ConverterInterface
 {
     /**
+     * @var mixed
+     */
+    protected $nullValue;
+
+    /**
+     * @param mixed $nullValue
+     */
+    public function __construct($nullValue = '')
+    {
+        $this->nullValue = $nullValue;
+    }
+
+    /**
      * @param mixed $item
      *
      * @return mixed
      */
     public function convert($item)
     {
-        if (is_array($item)) {
-            foreach ($item as $key => $value) {
-                if ($value === null) {
-                    $item[$key] = '';
-                }
-            }
-        } else {
-            if ($item === null) {
-                $item = '';
-            }
+        if ($item === null) {
+            $item = $this->nullValue;
         }
 
         return $item;

--- a/tests/Converter/NullConverterTest.php
+++ b/tests/Converter/NullConverterTest.php
@@ -29,18 +29,19 @@ class NullConverterTest extends \PHPUnit_Framework_TestCase
     {
         $converter = new NullConverter();
 
-        $this->assertEquals('', $converter->convert(null));
-        $this->assertEquals('foo', $converter->convert('foo'));
+        $this->assertSame('', $converter->convert(null));
+        $this->assertSame('foo', $converter->convert('foo'));
     }
 
     /**
      * @test
+     * @covers Plum\Plum\Converter\NullConverter::__construct()
      * @covers Plum\Plum\Converter\NullConverter::convert()
      */
-    public function convertShouldConvertNullToEmptyStringInArray()
+    public function convertShouldConvertNullToDefinedNullValue()
     {
-        $converter = new NullConverter();
+        $converter = new NullConverter(0);
 
-        $this->assertEquals(['a', ''], $converter->convert(['a', null]));
+        $this->assertSame(0, $converter->convert(null));
     }
 }


### PR DESCRIPTION
If $item is an array (or object) and elements of that array/object should be converted to a null value a value converter should be used. In addition the null value can now be defined
